### PR TITLE
update domain to current domain

### DIFF
--- a/app/config/config.dev.ts
+++ b/app/config/config.dev.ts
@@ -10,5 +10,6 @@ export default {
   // url to digital ocean droplet
   // API_URL: "http://165.22.6.21/v1/",
   // API_URL: "http://164.90.252.244/v1/",
-  API_URL: "https://api.zekereyna.dev/",
+  // API_URL: "https://api.zekereyna.dev/",
+  API_URL: "https://api.zeke.reyna.dev/",
 }

--- a/app/config/config.prod.ts
+++ b/app/config/config.prod.ts
@@ -8,5 +8,6 @@
 export default {
   // API_URL: "CHANGEME",
   // API_URL: "http://164.90.252.244/v1/",
-  API_URL: "https://api.zekereyna.dev/",
+  // API_URL: "https://api.zekereyna.dev/",
+  API_URL: "https://api.zeke.reyna.dev/",
 }


### PR DESCRIPTION
## Description

zekereyna.dev was registered under squarespace (after google sold off Google Domains) so bought reyna.dev under Cloudflare.

Needed to update the front-end accordingly after I setup DNS records for api.zeke.reyna.dev.